### PR TITLE
feat(rules): add --read-only flag for install.sh

### DIFF
--- a/templates/rules/conditional/read-only.md
+++ b/templates/rules/conditional/read-only.md
@@ -1,0 +1,23 @@
+# Read-Only Mode
+
+This project is in read-only mode.
+
+## Restricted (unless user explicitly asks)
+
+- Do NOT create, modify, or delete source code files
+- Do NOT run filesystem-modifying commands (mkdir, rm, cp, mv, npm install)
+- Do NOT stage, commit, or push changes
+- Do NOT modify configuration files
+
+## Always Allowed
+
+- Read and explore any files and directories
+- Run read-only commands (git status, git log, git diff, test suites)
+- Create and manage GitHub issues (gh issue create, gh issue edit)
+- Review and comment on PRs (gh pr review, gh pr comment)
+- Plan, analyze, and explain code
+- Search the codebase with any tools
+
+## Override
+
+When the user explicitly asks to modify files or write code, proceed for that request only. Return to read-only mode after completing the requested modification.

--- a/tests/bats/cli_args.bats
+++ b/tests/bats/cli_args.bats
@@ -25,6 +25,7 @@ parse_args() {
   SKIP_HOOKS=false
   SKIP_AGENTS=false
   DRY_RUN=false
+  READ_ONLY=false
   PROJECT_DIR=""
 
   while [[ $# -gt 0 ]]; do
@@ -39,6 +40,7 @@ parse_args() {
       --skip-hooks) SKIP_HOOKS=true; shift ;;
       --skip-agents) SKIP_AGENTS=true; shift ;;
       --dry-run) DRY_RUN=true; shift ;;
+      --read-only) READ_ONLY=true; shift ;;
       --project-dir) PROJECT_DIR="$2"; shift 2 ;;
       -h|--help) echo "help"; return 0 ;;
       *) echo "Unknown option: $1"; return 1 ;;
@@ -118,6 +120,23 @@ parse_args() {
   [ "$LANGUAGES" = "go,typescript" ]
   [ "$SKIP_HOOKS" = "true" ]
   [ "$DRY_RUN" = "true" ]
+}
+
+@test "parse_args: --read-only flag" {
+  parse_args --read-only
+  [ "$READ_ONLY" = "true" ]
+}
+
+@test "parse_args: defaults READ_ONLY to false" {
+  parse_args
+  [ "$READ_ONLY" = "false" ]
+}
+
+@test "parse_args: --read-only combined with other flags" {
+  parse_args --auto --read-only --force
+  [ "$READ_ONLY" = "true" ]
+  [ "$AUTO_MODE" = "true" ]
+  [ "$FORCE" = "true" ]
 }
 
 @test "parse_args: unknown option returns error" {

--- a/tests/bats/install_rules.bats
+++ b/tests/bats/install_rules.bats
@@ -85,6 +85,32 @@ teardown() {
   assert_dir_exists "$TEST_PROJECT_DIR/.claude/rules/typescript"
 }
 
+@test "install_rules: read-only rule not installed by default" {
+  install_rules "$TEST_PROJECT_DIR" "golang" "$TOOLKIT_ROOT/templates"
+  [ ! -f "$TEST_PROJECT_DIR/.claude/rules/common/read-only.md" ]
+}
+
+@test "install_rules: read-only rule installed when READ_ONLY=true" {
+  install_rules "$TEST_PROJECT_DIR" "" "$TOOLKIT_ROOT/templates"
+  # Simulate install.sh conditional copy
+  READ_ONLY=true
+  if [ "$READ_ONLY" = true ]; then
+    _tracked_copy "$TOOLKIT_ROOT/templates/rules/conditional/read-only.md" \
+      "$TEST_PROJECT_DIR/.claude/rules/common/read-only.md" \
+      ".claude/rules/common/read-only.md"
+  fi
+  assert_file_exists "$TEST_PROJECT_DIR/.claude/rules/common/read-only.md"
+}
+
+@test "install_rules: read-only rule contains expected sections" {
+  local rule="$TOOLKIT_ROOT/templates/rules/conditional/read-only.md"
+  assert_file_exists "$rule"
+  assert_file_contains "$rule" "Read-Only Mode"
+  assert_file_contains "$rule" "Restricted"
+  assert_file_contains "$rule" "Always Allowed"
+  assert_file_contains "$rule" "Override"
+}
+
 @test "install_rules: does not overwrite existing rules without force" {
   mkdir -p "$TEST_PROJECT_DIR/.claude/rules/common"
   echo "custom content" > "$TEST_PROJECT_DIR/.claude/rules/common/coding-style.md"


### PR DESCRIPTION
## Summary

- Adds `--read-only` flag to `install.sh` that installs a rule restricting Claude from modifying files unless explicitly asked
- Persists `readOnly: true` in `.claude-toolkit.json` — survives `--update` without needing to re-pass the flag
- Rule template lives in `templates/rules/conditional/` to avoid unconditional installation by `install_rules`
- GitHub operations (issues, PRs, reviews) are explicitly allowed in read-only mode

## Test plan

- [x] `bats tests/bats/` — all 240 tests pass (7 new)
- [x] `install.sh --read-only --auto --project-dir /tmp/test` — rule installed, config has `readOnly: true`
- [x] `install.sh --update --project-dir /tmp/test` — readOnly preserved without flag
- [x] `install.sh --update --read-only --project-dir ~/work/coding` — works on existing project
- [x] Install without `--read-only` — no `read-only.md` installed

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)