### PR TITLE
feat(detect): add workspace mode to discover tech stacks from subdirectories

### DIFF
--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -39,6 +39,19 @@ _find_subproject_dirs() {
     done
     return
   fi
+
+  # Workspace mode: discover git repos as sub-projects
+  # Only when no monorepo tool matched and dir is not itself a git repo
+  if [ ! -d "$dir/.git" ]; then
+    _find_workspace_repos "$dir"
+  fi
+}
+
+_find_workspace_repos() {
+  local dir="$1"
+  find "$dir" -maxdepth 4 -name ".git" -type d 2>/dev/null | while read -r gitdir; do
+    echo "${gitdir%/.git}"
+  done
 }
 
 _detect_tech_stack_in_dir() {


### PR DESCRIPTION
## Summary

- Adds workspace repo discovery as a fallback in `_find_subproject_dirs()` when no monorepo tool is detected and the directory is not itself a git repo
- Scans nested `.git` directories up to 4 levels deep via `find -maxdepth 4`
- Both `detect_tech_stack` and `detect_deep_domains` benefit automatically

Closes #19

## Test plan

- [x] 4 new bats tests covering workspace detection scenarios
- [x] Full suite green (257 tests)
- [x] Manual verification against real workspace (`~/work/coding` — 24 repos, detected `go unity docker node angular java python make` + `observability kubernetes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)